### PR TITLE
Add autosplitters for Creepy Tale (Full Game, Chapters, Individual Episodes)

### DIFF
--- a/LiveSplit.AutoSplitters.xml
+++ b/LiveSplit.AutoSplitters.xml
@@ -2,6 +2,126 @@
 <AutoSplitters>
     <AutoSplitter>
         <Games>
+            <Game>Creepy Tale</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/EnkiSpeedruns/CreepyTale-Autosplitters/raw/main/full_game.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Full game autosplitter by Enki</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Creepy Tale - Chapter 1</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/EnkiSpeedruns/CreepyTale-Autosplitters/raw/main/chapter_1.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Chapter 1 autosplitter (Episodes 1–3)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Creepy Tale - Chapter 2</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/EnkiSpeedruns/CreepyTale-Autosplitters/raw/main/chapter_2.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Chapter 2 autosplitter (Episodes 4–6)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Creepy Tale - Chapter 3</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/EnkiSpeedruns/CreepyTale-Autosplitters/raw/main/chapter_3.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Chapter 3 autosplitter (Episodes 7–8)</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Creepy Tale - Episode 1</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/EnkiSpeedruns/CreepyTale-Autosplitters/raw/main/episode_1.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Episode 1 autosplitter</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Creepy Tale - Episode 2</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/EnkiSpeedruns/CreepyTale-Autosplitters/raw/main/episode_2.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Episode 2 autosplitter</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Creepy Tale - Episode 3</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/EnkiSpeedruns/CreepyTale-Autosplitters/raw/main/episode_3.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Episode 3 autosplitter</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Creepy Tale - Episode 4</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/EnkiSpeedruns/CreepyTale-Autosplitters/raw/main/episode_4.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Episode 4 autosplitter</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Creepy Tale - Episode 5</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/EnkiSpeedruns/CreepyTale-Autosplitters/raw/main/episode_5.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Episode 5 autosplitter</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Creepy Tale - Episode 6</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/EnkiSpeedruns/CreepyTale-Autosplitters/raw/main/episode_6.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Episode 6 autosplitter</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Creepy Tale - Episode 7</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/EnkiSpeedruns/CreepyTale-Autosplitters/raw/main/episode_7.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Episode 7 autosplitter</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
+            <Game>Creepy Tale - Episode 8</Game>
+        </Games>
+        <URLs>
+            <URL>https://github.com/EnkiSpeedruns/CreepyTale-Autosplitters/raw/main/episode_8.asl</URL>
+        </URLs>
+        <Type>Script</Type>
+        <Description>Episode 8 autosplitter — Manual reset required after ending</Description>
+    </AutoSplitter>
+    <AutoSplitter>
+        <Games>
             <Game>Call of the Sea</Game>
         </Games>
         <URLs>


### PR DESCRIPTION
This pull request adds autosplitter scripts for the game *Creepy Tale*, covering:

- Full Game
- Chapter 1 (Episodes 1–3)
- Chapter 2 (Episodes 4–6)
- Chapter 3 (Episodes 7–8)
- Individual Episodes (1 through 8)

Each script includes:
- Auto-start
- Auto-split
- Auto-reset

🔔 Note: Episode 8 ends with a transition from level 8 → 0, which is the same value used by the main menu. Because of that, a manual timer reset is required when running Episode 8 individually.

All scripts are hosted at:
https://github.com/EnkiSpeedruns/CreepyTale-Autosplitters

Thank you!